### PR TITLE
[DGB-6] Correção feita no H264Parser

### DIFF
--- a/Examples/SimpleRtspPlayer/GUI/ViewModels/MainWindowViewModel.cs
+++ b/Examples/SimpleRtspPlayer/GUI/ViewModels/MainWindowViewModel.cs
@@ -74,7 +74,7 @@ namespace SimpleRtspPlayer.GUI.ViewModels
             var connectionParameters = !string.IsNullOrEmpty(deviceUri.UserInfo) ? new ConnectionParameters(deviceUri) : 
                 new ConnectionParameters(deviceUri, credential);
 
-            connectionParameters.RtpTransport = RtpTransportProtocol.UDP;
+            connectionParameters.RtpTransport = RtpTransportProtocol.TCP;
             connectionParameters.CancelTimeout = TimeSpan.FromSeconds(1);
 
             _mainWindowModel.Start(connectionParameters);

--- a/Examples/SimpleRtspPlayer/SimpleRtspPlayer.csproj
+++ b/Examples/SimpleRtspPlayer/SimpleRtspPlayer.csproj
@@ -233,4 +233,8 @@
 		xcopy $(ProjectDir)..\libffmpeghelper\x64\$(Configuration)\libffmpeghelper.dll  $(TargetDir)  /Y /E /C /F
 	</PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>copy $(ProjectDir)$(PlatformName)\*.dll $(TargetDir)
+copy $(ProjectDir)..\libffmpeghelper\$(PlatformName)\$(ConfigurationName)\libffmpeghelper.dll $(TargetDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Examples/libffmpeghelper/libffmpeghelper.vcxproj
+++ b/Examples/libffmpeghelper/libffmpeghelper.vcxproj
@@ -39,32 +39,32 @@
     <ProjectGuid>{3C96BD24-3212-4CD8-86E3-63D1E3E38155}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libffmpeghelper</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/RtspClientSharp.sln
+++ b/RtspClientSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31313.79
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RtspClientSharp", "RtspClientSharp\RtspClientSharp.csproj", "{DC94331F-847E-4456-BD27-F147551750FB}"
 EndProject
@@ -87,8 +87,8 @@ Global
 		{FD515510-7EBA-45A4-AC0A-2C6993DD0FBC}.Release|x64.Build.0 = Release|x64
 		{FD515510-7EBA-45A4-AC0A-2C6993DD0FBC}.Release|x86.ActiveCfg = Release|x86
 		{FD515510-7EBA-45A4-AC0A-2C6993DD0FBC}.Release|x86.Build.0 = Release|x86
-		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|Any CPU.Build.0 = Debug|x86
 		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|x64.ActiveCfg = Debug|x64
 		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|x64.Build.0 = Debug|x64
 		{40493D0C-21B8-4357-AE75-D7637B3FC223}.Debug|x86.ActiveCfg = Debug|x86

--- a/RtspClientSharp/MediaParsers/H264Parser.cs
+++ b/RtspClientSharp/MediaParsers/H264Parser.cs
@@ -24,7 +24,7 @@ namespace RtspClientSharp.MediaParsers
         private readonly BitStreamReader _bitStreamReader = new BitStreamReader();
         private readonly Dictionary<int, byte[]> _spsMap = new Dictionary<int, byte[]>();
         private readonly Dictionary<int, byte[]> _ppsMap = new Dictionary<int, byte[]>();
-        private bool _waitForIFrame = true;
+        private bool _waitForIFrame = false;
         private byte[] _spsPpsBytes = new byte[0];
         private bool _updateSpsPpsBytes;
         private int _sliceType = -1;
@@ -99,7 +99,7 @@ namespace RtspClientSharp.MediaParsers
         {
             _frameStream.Position = 0;
             _sliceType = -1;
-            _waitForIFrame = true;
+            _waitForIFrame = false;
         }
 
         private void SlicerOnNalUnitFound(ArraySegment<byte> byteSegment)


### PR DESCRIPTION
[DGB-6] Correção feita no H264Parser para exibir os PFrames que antes estavam sendo "ignorados". Alterações feitas no projeto "SimpleRtspPlayer" e no "libffmpeghelper" apenas para poder utilizar o projeto para validações em maquina local.