### PR TITLE
[DGB-93] Changed _samplesSum and _previousTimestamp types to allow negative values

### DIFF
--- a/RtspClientSharp/Rtp/RtpStream.cs
+++ b/RtspClientSharp/Rtp/RtpStream.cs
@@ -10,9 +10,9 @@ namespace RtspClientSharp.Rtp
         private readonly IMediaPayloadParser _mediaPayloadParser;
         private readonly int _samplesFrequency;
 
-        private ulong _samplesSum;
+        private long _samplesSum;
         private ushort _previousSeqNumber;
-        private uint _previousTimestamp;
+        private int _previousTimestamp;
         private bool _isFirstPacket = true;
 
         public uint SyncSourceId { get; private set; }
@@ -74,7 +74,7 @@ namespace RtspClientSharp.Rtp
                 if (rtpPacket.SeqNumber < HighestSequenceNumberReceived)
                     ++SequenceCycles;
 
-                _samplesSum += rtpPacket.Timestamp - _previousTimestamp;
+                _samplesSum += rtpPacket.Timestamp - _previousTimestamp;       
             }
 
             HighestSequenceNumberReceived = rtpPacket.SeqNumber;
@@ -82,7 +82,7 @@ namespace RtspClientSharp.Rtp
             _isFirstPacket = false;
             ++PacketsReceivedSinceLastReset;
             _previousSeqNumber = rtpPacket.SeqNumber;
-            _previousTimestamp = rtpPacket.Timestamp;
+            _previousTimestamp = (int)rtpPacket.Timestamp;
 
             if (rtpPacket.PayloadSegment.Count == 0)
                 return;

--- a/RtspClientSharp/RtspClientSharp.csproj
+++ b/RtspClientSharp/RtspClientSharp.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://github.com/BogdanovKirill/RtspClientSharp/blob/master/Images/package_icon.png?raw=true</PackageIconUrl>
     <Copyright>Copyright ©2019 Kirill Bogdanov</Copyright>
-    <Version>1.5</Version>
+    <Version>1.5.1</Version>
     <PackageReleaseNotes>-Bug fix: Additional check for NAL start marker was added. That should resolve issue with some cameras which sends one NAL for one frame without start bytes (0 0 0 1)
 
 More info: https://github.com/BogdanovKirill/RtspClientSharp/issues/49</PackageReleaseNotes>


### PR DESCRIPTION
At some point of the edge recording the subtraction between these two values were resulting in an nonsense value. After this point the frames's timestamps jumped to hours ahead, but the video was still being showed as nothing happened. This correction was made focused in the Player.NET's scenario.